### PR TITLE
Update r.sh

### DIFF
--- a/template/r.sh
+++ b/template/r.sh
@@ -5,8 +5,9 @@
 set -e
 
 # Define the R version explicitly
+# Define the R version explicitly
+# Chosen for compatibility with specific dependencies
 R_VERSION="4.5.0"
-R_URL="https://cloud.r-project.org/bin/macosx/big-sur-arm64/base/R-${R_VERSION}-arm64.pkg"
 
 # Print the R version being installed
 echo "Installing R version: $R_VERSION"

--- a/template/r.sh
+++ b/template/r.sh
@@ -4,11 +4,17 @@
 #!/usr/bin/env bash
 set -e
 
+# Define the R version explicitly
+R_VERSION="4.5.0"
+R_URL="https://cloud.r-project.org/bin/macosx/big-sur-arm64/base/R-${R_VERSION}-arm64.pkg"
+
+# Print the R version being installed
+echo "Installing R version: $R_VERSION"
+
 # Download and extract the main Mac Resources directory
 # Updated as Sonoma / m1
 mkdir -p r-mac
-curl -o r-mac/latest_r.pkg \
-    https://cloud.r-project.org/bin/macosx/big-sur-arm64/base/R-4.5.0-arm64.pkg
+curl -o r-mac/latest_r.pkg "$R_URL"
 
 cd r-mac
 xar -xf latest_r.pkg
@@ -25,6 +31,6 @@ sed -i.bak 's;/Library/Frameworks/R.framework/Resources;${R_HOME};g' \
 chmod +x bin/R
 rm -f bin/R.bak
 
-# Remove unneccessary files
+# Remove unnecessary files
 rm -r doc tests
 rm -r lib/*.dSYM


### PR DESCRIPTION
This pull request updates the `template/r.sh` script to improve maintainability and clarity by introducing an explicit R version variable and making minor corrections. 

### Improvements to maintainability and clarity:

* Defined the R version explicitly using a `R_VERSION` variable and updated the download URL to use this variable dynamically. Added a print statement to display the R version being installed. (`template/r.sh`, [template/r.shR7-R17](diffhunk://#diff-a3574e4bdae95da0bc67e090d1206439bb87b39df10af7cb2909a6f2b07264c0R7-R17))
* Corrected a typo in a comment from "unneccessary" to "unnecessary." (`template/r.sh`, [template/r.shL28-R34](diffhunk://#diff-a3574e4bdae95da0bc67e090d1206439bb87b39df10af7cb2909a6f2b07264c0L28-R34))