### PR TITLE
add faithful example

### DIFF
--- a/commands/init.js
+++ b/commands/init.js
@@ -58,15 +58,24 @@ export const initCommand = new Command("init")
       const newAppPath = path.join(shinyPath, "app.R");
 
       // Remove existing app.R if it exists
-      if (fs.existsSync(oldAppPath)) {
+      try {
         fs.rmSync(oldAppPath);
         console.log("🗑️ Removed existing app.R");
+      } catch (err) {
+        console.error("❌ Error removing existing app.R:", err.message);
       }
 
       // Rename 01-faithful.R to app.R
       if (fs.existsSync(faithfulPath)) {
-        fs.renameSync(faithfulPath, newAppPath);
-        console.log("✅ Renamed 01-faithful.R to app.R");
+        try {
+          fs.renameSync(faithfulPath, newAppPath);
+          console.log("✅ Renamed 01-faithful.R to app.R");
+        } catch (err) {
+          console.error(
+            "❌ Error renaming 01-faithful.R to app.R:",
+            err.message
+          );
+        }
       } else {
         console.warn("⚠️  01-faithful.R not found in the shiny directory.");
       }

--- a/commands/init.js
+++ b/commands/init.js
@@ -50,6 +50,28 @@ export const initCommand = new Command("init")
     execSync(`cp -r ${templatePath}/shiny ${projectPath}`);
     execSync(`cp -r ${templatePath}/src ${projectPath}`);
 
+    // If name is "ex01", handle app.R and 01-faithful.R
+    if (name === "ex01") {
+      const shinyPath = path.join(projectPath, "shiny");
+      const oldAppPath = path.join(shinyPath, "app.R");
+      const faithfulPath = path.join(shinyPath, "01-faithful.R");
+      const newAppPath = path.join(shinyPath, "app.R");
+
+      // Remove existing app.R if it exists
+      if (fs.existsSync(oldAppPath)) {
+        fs.rmSync(oldAppPath);
+        console.log("🗑️ Removed existing app.R");
+      }
+
+      // Rename 01-faithful.R to app.R
+      if (fs.existsSync(faithfulPath)) {
+        fs.renameSync(faithfulPath, newAppPath);
+        console.log("✅ Renamed 01-faithful.R to app.R");
+      } else {
+        console.warn("⚠️  01-faithful.R not found in the shiny directory.");
+      }
+    }
+
     const copy = (file) => {
       const from = path.join(templatePath, file);
       const to = path.join(projectPath, file);

--- a/template/shiny/01-faithful.R
+++ b/template/shiny/01-faithful.R
@@ -1,0 +1,52 @@
+ui <- bootstrapPage(
+  selectInput(
+    inputId = "n_breaks",
+    label = "Number of bins in histogram (approximate):",
+    choices = c(10, 20, 35, 50),
+    selected = 20
+  ),
+  checkboxInput(
+    inputId = "individual_obs",
+    label = strong("Show individual observations"),
+    value = FALSE
+  ),
+  checkboxInput(
+    inputId = "density",
+    label = strong("Show density estimate"),
+    value = FALSE
+  ),
+  plotOutput(outputId = "main_plot", height = "300px"),
+
+  # Display this only if the density is shown
+  conditionalPanel(
+    condition = "input.density == true",
+    sliderInput(
+      inputId = "bw_adjust",
+      label = "Bandwidth adjustment:",
+      min = 0.2, max = 2, value = 1, step = 0.2
+    )
+  )
+)
+
+server <- function(input, output) {
+  output$main_plot <- renderPlot({
+    hist(faithful$eruptions,
+      probability = TRUE,
+      breaks = as.numeric(input$n_breaks),
+      xlab = "Duration (minutes)",
+      main = "Geyser eruption duration"
+    )
+
+    if (input$individual_obs) {
+      rug(faithful$eruptions)
+    }
+
+    if (input$density) {
+      dens <- density(faithful$eruptions,
+        adjust = input$bw_adjust
+      )
+      lines(dens, col = "blue")
+    }
+  })
+}
+shinyApp(ui = ui, server = server)


### PR DESCRIPTION
This pull request introduces functionality to handle specific file operations when initializing a project with the name "ex01" and adds a new Shiny app template for data visualization. The most important changes include conditional file renaming and removal logic in the `init` command and the addition of a Shiny app script for visualizing geyser eruption data.

### Enhancements to the `init` command:
* Added logic in `commands/init.js` to handle the case where the project name is "ex01." This includes removing an existing `app.R` file if it exists and renaming `01-faithful.R` to `app.R` in the `shiny` directory.

### New Shiny app template:
* Added a new Shiny app script in `template/shiny/01-faithful.R` for visualizing geyser eruption durations. The app includes a histogram with adjustable bins, options to show individual observations, and a density estimate with customizable bandwidth.