### PR TITLE
docs: mention nhyris dependency

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -177,16 +177,36 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <section id="how-to-use" class="level2">
 <h2 class="anchored" data-anchor-id="how-to-use">How to use</h2>
 <ol type="1">
-<li><p>clone repository</p></li>
-<li><p>initialize project with</p></li>
+<li><p>clone repository: either fork or clone is OK</p></li>
+<li><p>install dependencies</p></li>
 </ol>
-<div class="sourceCode" id="cb1"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">nhyris</span> init myapp</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>node version &gt;= 22.13.1 (LTS: 22.15)</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">node</span> <span class="at">-v</span> </span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">npm</span> install </span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="ex">npm</span> link </span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<div class="callout callout-style-default callout-note callout-titled">
+<div class="callout-header d-flex align-content-center">
+<div class="callout-icon-container">
+<i class="callout-icon"></i>
+</div>
+<div class="callout-title-container flex-fill">
+Note
+</div>
+</div>
+<div class="callout-body-container callout-body">
+<p>please use zsh or git-bash not powershell</p>
+</div>
+</div>
 <ol start="3" type="1">
+<li>initialize project with</li>
+</ol>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">nhyris</span> init myapp</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<ol start="4" type="1">
 <li><p>modify your shiny application</p></li>
 <li><p>Modify shiny and Run your application</p></li>
 </ol>
 <p>Code for shiny is in <strong>“myapp/shiny/app.R”</strong></p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">nhyris</span> run myapp</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<div class="sourceCode" id="cb3"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="ex">nhyris</span> run myapp</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <div class="callout callout-style-default callout-note callout-titled">
 <div class="callout-header d-flex align-content-center">
 <div class="callout-icon-container">
@@ -200,18 +220,18 @@ Note
 <p>nhyris supports single file: not <code>ui.R</code> &amp; <code>server.R</code></p>
 </div>
 </div>
-<ol start="4" type="1">
+<ol start="6" type="1">
 <li>build application into electron</li>
 </ol>
-<div class="sourceCode" id="cb3"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="ex">nhyris</span> build myapp</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
-<ol start="5" type="1">
+<div class="sourceCode" id="cb4"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="ex">nhyris</span> build myapp</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<ol start="7" type="1">
 <li>Share your result</li>
 </ol>
 <p>results exists in “out”</p>
 </section>
 <section id="app.r-template-from-shiny-galleries" class="level2">
 <h2 class="anchored" data-anchor-id="app.r-template-from-shiny-galleries">app.R template from Shiny Galleries</h2>
-<div class="sourceCode" id="cb4"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="ex">nhyris</span> init ex01</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<div class="sourceCode" id="cb5"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="ex">nhyris</span> init ex01</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 
 
 </section>

--- a/docs/search.json
+++ b/docs/search.json
@@ -60,7 +60,7 @@
     "href": "index.html#how-to-use",
     "title": "nhyris",
     "section": "How to use",
-    "text": "How to use\n\nclone repository\ninitialize project with\n\nnhyris init myapp\n\nmodify your shiny application\nModify shiny and Run your application\n\nCode for shiny is in “myapp/shiny/app.R”\nnhyris run myapp\n\n\n\n\n\n\nNote\n\n\n\nnhyris supports single file: not ui.R & server.R\n\n\n\nbuild application into electron\n\nnhyris build myapp\n\nShare your result\n\nresults exists in “out”"
+    "text": "How to use\n\nclone repository: either fork or clone is OK\ninstall dependencies\n\nnode version &gt;= 22.13.1 (LTS: 22.15)\nnode -v \nnpm install \nnpm link \n\n\n\n\n\n\nNote\n\n\n\nplease use zsh or git-bash not powershell\n\n\n\ninitialize project with\n\nnhyris init myapp\n\nmodify your shiny application\nModify shiny and Run your application\n\nCode for shiny is in “myapp/shiny/app.R”\nnhyris run myapp\n\n\n\n\n\n\nNote\n\n\n\nnhyris supports single file: not ui.R & server.R\n\n\n\nbuild application into electron\n\nnhyris build myapp\n\nShare your result\n\nresults exists in “out”"
   },
   {
     "objectID": "index.html#app.r-template-from-shiny-galleries",

--- a/index.qmd
+++ b/index.qmd
@@ -6,18 +6,32 @@ title: "nhyris"
 
 ## How to use
 
-1. clone repository
+1. clone repository: either fork or clone is OK
 
-2. initialize project with
+2. install dependencies
+
+node version >= 22.13.1 (LTS: 22.15)
+
+```sh
+node -v 
+npm install 
+npm link 
+```
+
+::: {.callout-note}
+please use zsh or git-bash not powershell
+:::
+
+3. initialize project with
 
 ```sh
 nhyris init myapp
 ```
 
-3. modify your shiny application
+4. modify your shiny application
 
 
-4. Modify shiny and Run your application
+5. Modify shiny and Run your application
 
 Code for shiny is in **"myapp/shiny/app.R"**
 
@@ -29,16 +43,15 @@ nhyris run myapp
 nhyris supports single file: not `ui.R` & `server.R`
 :::
 
-4. build application into electron
+6. build application into electron
 
 ```sh
 nhyris build myapp
 ```
 
-5. Share your result
+7. Share your result
 
 results exists in "out"
-
 
 ## app.R template from Shiny Galleries 
 


### PR DESCRIPTION
This pull request updates the documentation for the `nhyris` project to improve clarity and provide additional setup instructions. The changes include updates to the "How to use" section, adjustments to the step numbering, and enhancements to the formatting of instructions.

### Documentation Updates:

* **Improved setup instructions:**
  - Updated the "clone repository" step to clarify that both forking and cloning are acceptable. [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL180-R209) [[2]](diffhunk://#diff-142d492309aec76ce25caedd8d7eb0bdfe11ecdfa91f60eb015f56a406a41446L9-R34)
  - Added a new step for installing dependencies, specifying the required Node.js version (`>= 22.13.1`) and providing commands for checking the Node.js version, installing dependencies, and linking the package. [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL180-R209) [[2]](diffhunk://#diff-142d492309aec76ce25caedd8d7eb0bdfe11ecdfa91f60eb015f56a406a41446L9-R34)
  - Included a note recommending the use of `zsh` or `git-bash` instead of PowerShell. [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL180-R209) [[2]](diffhunk://#diff-142d492309aec76ce25caedd8d7eb0bdfe11ecdfa91f60eb015f56a406a41446L9-R34)

* **Step reordering and numbering:**
  - Adjusted the numbering of steps to accommodate the new "install dependencies" step and ensure proper sequence for initializing the project, modifying the application, building it into Electron, and sharing the results. [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL203-R234) [[2]](diffhunk://#diff-142d492309aec76ce25caedd8d7eb0bdfe11ecdfa91f60eb015f56a406a41446L32-L42)

* **Formatting and consistency improvements:**
  - Updated the JSON search index (`docs/search.json`) to reflect the revised text and structure of the "How to use" section.
  - Enhanced the Markdown formatting in `index.qmd` for better readability and consistency with the HTML documentation. [[1]](diffhunk://#diff-142d492309aec76ce25caedd8d7eb0bdfe11ecdfa91f60eb015f56a406a41446L9-R34) [[2]](diffhunk://#diff-142d492309aec76ce25caedd8d7eb0bdfe11ecdfa91f60eb015f56a406a41446L32-L42)