### PR TITLE
feat: add example

### DIFF
--- a/gallery.json
+++ b/gallery.json
@@ -2,5 +2,6 @@
   "ex01": "01-faithful.R",
   "ex02": "02-kmeans.R",
   "ex03": "03-single.R",
-  "ex04": "04-telephones.R"
+  "ex04": "04-telephones.R",
+  "ex07": "07-googlecharts.R"
 }

--- a/template/shiny/07-googlecharts.R
+++ b/template/shiny/07-googlecharts.R
@@ -1,0 +1,169 @@
+# More info:
+#   https://github.com/jcheng5/googleCharts
+# Install:
+#   devtools::install_github("jcheng5/googleCharts")
+library(googleCharts)
+library(shiny)
+library(dplyr)
+
+#### nhyris
+####
+####
+####
+#### fixed url
+
+data <- readRDS(url(
+    "https://github.com/rstudio/shiny-examples/raw/refs/heads/main/182-google-charts/healthexp.Rds"
+))
+head(data)
+
+data$Region <- as.factor(data$Region)
+
+# Use global max/min for axes so the view window stays
+# constant as the user moves between years
+xlim <- list(
+    min = min(data$Health.Expenditure) - 500,
+    max = max(data$Health.Expenditure) + 500
+)
+ylim <- list(
+    min = min(data$Life.Expectancy),
+    max = max(data$Life.Expectancy) + 3
+)
+
+ui <- fluidPage(
+    # This line loads the Google Charts JS library
+    googleChartsInit(),
+
+    # Use the Google webfont "Source Sans Pro"
+    tags$link(
+        href = paste0(
+            "http://fonts.googleapis.com/css?",
+            "family=Source+Sans+Pro:300,600,300italic"
+        ),
+        rel = "stylesheet",
+        type = "text/css"
+    ),
+    tags$style(type = "text/css", "body {font-family: 'Source Sans Pro'}"),
+
+    h2("Google Charts demo"),
+
+    googleBubbleChart(
+        "chart",
+        width = "100%",
+        height = "475px",
+        # Set the default options for this chart; they can be
+        # overridden in server.R on a per-update basis. See
+        # https://developers.google.com/chart/interactive/docs/gallery/bubblechart
+        # for option documentation.
+        options = list(
+            fontName = "Source Sans Pro",
+            fontSize = 13,
+            # Set axis labels and ranges
+            hAxis = list(
+                title = "Health expenditure, per capita ($USD)",
+                viewWindow = xlim
+            ),
+            vAxis = list(
+                title = "Life expectancy (years)",
+                viewWindow = ylim
+            ),
+            # The default padding is a little too spaced out
+            chartArea = list(
+                top = 50,
+                left = 75,
+                height = "75%",
+                width = "75%"
+            ),
+            # Allow pan/zoom
+            explorer = list(),
+            # Set bubble visual props
+            bubble = list(
+                opacity = 0.4,
+                stroke = "none",
+                # Hide bubble label
+                textStyle = list(
+                    color = "none"
+                )
+            ),
+            # Set fonts
+            titleTextStyle = list(
+                fontSize = 16
+            ),
+            tooltip = list(
+                textStyle = list(
+                    fontSize = 12
+                )
+            )
+        )
+    ),
+    fluidRow(
+        shiny::column(
+            4,
+            offset = 4,
+            sliderInput(
+                "year",
+                "Year",
+                min = min(data$Year),
+                max = max(data$Year),
+                value = min(data$Year),
+                animate = TRUE
+            )
+        )
+    )
+)
+
+
+server <- function(input, output, session) {
+    # Provide explicit colors for regions, so they don't get recoded when the
+    # different series happen to be ordered differently from year to year.
+    # http://andrewgelman.com/2014/09/11/mysterious-shiny-things/
+    defaultColors <- c(
+        "#3366cc",
+        "#dc3912",
+        "#ff9900",
+        "#109618",
+        "#990099",
+        "#0099c6",
+        "#dd4477"
+    )
+    series <- structure(
+        lapply(defaultColors, function(color) {
+            list(color = color)
+        }),
+        names = levels(data$Region)
+    )
+
+    yearData <- reactive({
+        # Filter to the desired year, and put the columns
+        # in the order that Google's Bubble Chart expects
+        # them (name, x, y, color, size). Also sort by region
+        # so that Google Charts orders and colors the regions
+        # consistently.
+        df <- data %>%
+            filter(Year == input$year) %>%
+            select(
+                Country,
+                Health.Expenditure,
+                Life.Expectancy,
+                Region,
+                Population
+            ) %>%
+            arrange(Region)
+    })
+
+    output$chart <- reactive({
+        # Return the data and options
+        list(
+            data = googleDataTable(yearData()),
+            options = list(
+                title = sprintf(
+                    "Health expenditure vs. life expectancy, %s",
+                    input$year
+                ),
+                series = series
+            )
+        )
+    })
+}
+
+shinyApp(ui = ui, server = server)


### PR DESCRIPTION
This pull request adds a new example to the gallery and includes a corresponding Shiny application file for demonstrating Google Charts integration. The most important changes include updating the `gallery.json` file and adding a new Shiny application script.

### Updates to the gallery:
* [`gallery.json`](diffhunk://#diff-0b884235535f1a24d03c6a5a31cad797f7dd65c708988ff0f1b948ae73bcd370L5-R6): Added a new entry for `ex07` pointing to the `07-googlecharts.R` example.

### New Shiny application:
* [`template/shiny/07-googlecharts.R`](diffhunk://#diff-3a68922cc5dd74234bcd7f0a0fbee0cc9b6287a8ca0e8fc7039c793d664cc0edR1-R169): Introduced a new Shiny application that demonstrates the use of Google Charts for visualizing health expenditure versus life expectancy. The app includes a slider for selecting the year, a reactive data filter, and a Google Bubble Chart with customized options.