### PR TITLE
feat: ex10

### DIFF
--- a/gallery.json
+++ b/gallery.json
@@ -3,5 +3,6 @@
   "ex02": "02-kmeans.R",
   "ex03": "03-single.R",
   "ex04": "04-telephones.R",
-  "ex07": "07-googlecharts.R"
+  "ex07": "07-googlecharts.R",
+  "ex10": "10-datatable.R"
 }

--- a/template/shiny/10-datatable.R
+++ b/template/shiny/10-datatable.R
@@ -1,0 +1,56 @@
+# Load the ggplot2 package which provides
+# the 'mpg' dataset.
+library(ggplot2)
+
+ui <- fluidPage(
+    titlePanel("Basic DataTable"),
+
+    # Create a new Row in the UI for selectInputs
+    fluidRow(
+        column(
+            4,
+            selectInput(
+                "man",
+                "Manufacturer:",
+                c("All", unique(as.character(mpg$manufacturer)))
+            )
+        ),
+        column(
+            4,
+            selectInput(
+                "trans",
+                "Transmission:",
+                c("All", unique(as.character(mpg$trans)))
+            )
+        ),
+        column(
+            4,
+            selectInput(
+                "cyl",
+                "Cylinders:",
+                c("All", unique(as.character(mpg$cyl)))
+            )
+        )
+    ),
+    # Create a new row for the table.
+    DT::dataTableOutput("table")
+)
+
+server <- function(input, output) {
+    # Filter data based on selections
+    output$table <- DT::renderDataTable(DT::datatable({
+        data <- mpg
+        if (input$man != "All") {
+            data <- data[data$manufacturer == input$man, ]
+        }
+        if (input$cyl != "All") {
+            data <- data[data$cyl == input$cyl, ]
+        }
+        if (input$trans != "All") {
+            data <- data[data$trans == input$trans, ]
+        }
+        data
+    }))
+}
+
+shinyApp(ui = ui, server = server)


### PR DESCRIPTION
This pull request introduces a new Shiny example application and updates the `gallery.json` file to include it. The new example demonstrates how to create an interactive DataTable with filtering options based on the `mpg` dataset.

### Addition of a new Shiny example:

* [`template/shiny/10-datatable.R`](diffhunk://#diff-34c9fad49bd3d122c483513c3818a01689500ed1882e6b93cf13fe02d8a5c7b6R1-R56): Added a new Shiny app example that uses the `DT` package to create an interactive DataTable with filtering options for manufacturer, transmission, and cylinders. The app also demonstrates the use of the `mpg` dataset from the `ggplot2` package.

### Update to the gallery metadata:

* [`gallery.json`](diffhunk://#diff-0b884235535f1a24d03c6a5a31cad797f7dd65c708988ff0f1b948ae73bcd370L6-R7): Added an entry for the new Shiny example (`10-datatable.R`) to the gallery metadata, ensuring it is included in the list of available examples.