### PR TITLE
feat: ex39

### DIFF
--- a/gallery.json
+++ b/gallery.json
@@ -6,5 +6,6 @@
   "ex07": "07-googlecharts.R",
   "ex10": "10-datatable.R",
   "ex26": "26-absolute.R",
-  "ex36": "36-dynamic.R"
+  "ex36": "36-dynamic.R",
+  "ex39": "39-observer.R"
 }

--- a/template/shiny/39-observer.R
+++ b/template/shiny/39-observer.R
@@ -1,0 +1,62 @@
+ui <- fluidPage(
+    titlePanel("Observer demo"),
+    mainPanel(
+        p(
+            "This demo writes the value of the slider to a log file. If you can, check the file contents after moving the slider to confirm it's been appended to."
+        ),
+        verbatimTextOutput('logfile'),
+        fluidRow(
+            column(
+                4,
+                wellPanel(
+                    sliderInput(
+                        "n",
+                        "N:",
+                        min = 10,
+                        max = 1000,
+                        value = 200,
+                        step = 10
+                    )
+                )
+            ),
+            column(
+                8,
+                verbatimTextOutput("text"),
+                br(),
+                br(),
+                p(
+                    "In this example, what's visible in the client isn't",
+                    "what's interesting. The server is writing to a log",
+                    "file each time the slider value changes."
+                )
+            )
+        )
+    )
+)
+
+server <- function(input, output, session) {
+    # Create a random name for the log file
+    logfilename <- tempfile('logfile', fileext = '.txt')
+
+    output$logfile <- renderText({
+        sprintf("Log file: %s", logfilename)
+    })
+
+    # This observer adds an entry to the log file every time
+    # input$n changes.
+    obs <- observe({
+        cat(input$n, '\n', file = logfilename, append = TRUE)
+    })
+
+    session$onSessionEnded(function() {
+        # When the client ends the session, clean up the log file
+        # for this session.
+        unlink(logfilename)
+    })
+
+    output$text <- renderText({
+        paste0("The value of input$n is: ", input$n)
+    })
+}
+
+shinyApp(ui = ui, server = server)


### PR DESCRIPTION
This pull request introduces a new Shiny example application (`ex39`) to demonstrate the use of observers in R, along with an update to the `gallery.json` file to include the new example. The most important changes are as follows:

### Addition of a new Shiny example:

* [`template/shiny/39-observer.R`](diffhunk://#diff-86a1c811b3b618654e5e491864fc258a124395947bb51258e594fc4b766ace3aR1-R62): Added a new Shiny app demonstrating the use of an observer to log slider input changes to a temporary file. The app includes a UI with a slider and output elements, and a server function that writes slider values to a log file and cleans up the file when the session ends.

### Update to the gallery index:

* [`gallery.json`](diffhunk://#diff-0b884235535f1a24d03c6a5a31cad797f7dd65c708988ff0f1b948ae73bcd370L9-R10): Updated the gallery index to include the new example `ex39` (`39-observer.R`).