### PR TITLE
feat: ex13

### DIFF
--- a/gallery.json
+++ b/gallery.json
@@ -6,6 +6,7 @@
   "ex07": "07-googlecharts.R",
   "ex08": "08-movieexploer.R",
   "ex10": "10-datatable.R",
+  "ex13": "13-datatables-demo.R",
   "ex26": "26-absolute.R",
   "ex36": "36-dynamic.R",
   "ex39": "39-observer.R",

--- a/template/shiny/13-datatables-demo.R
+++ b/template/shiny/13-datatables-demo.R
@@ -1,0 +1,58 @@
+library(shiny)
+library(ggplot2) # for the diamonds dataset
+
+ui <- fluidPage(
+    title = "Examples of DataTables",
+    sidebarLayout(
+        sidebarPanel(
+            conditionalPanel(
+                'input.dataset === "diamonds"',
+                checkboxGroupInput(
+                    "show_vars",
+                    "Columns in diamonds to show:",
+                    names(diamonds),
+                    selected = names(diamonds)
+                )
+            ),
+            conditionalPanel(
+                'input.dataset === "mtcars"',
+                helpText("Click the column header to sort a column.")
+            ),
+            conditionalPanel(
+                'input.dataset === "iris"',
+                helpText("Display 5 records by default.")
+            )
+        ),
+        mainPanel(
+            tabsetPanel(
+                id = 'dataset',
+                tabPanel("diamonds", DT::dataTableOutput("mytable1")),
+                tabPanel("mtcars", DT::dataTableOutput("mytable2")),
+                tabPanel("iris", DT::dataTableOutput("mytable3"))
+            )
+        )
+    )
+)
+
+server <- function(input, output) {
+    # choose columns to display
+    diamonds2 = diamonds[sample(nrow(diamonds), 1000), ]
+    output$mytable1 <- DT::renderDataTable({
+        DT::datatable(diamonds2[, input$show_vars, drop = FALSE])
+    })
+
+    # sorted columns are colored now because CSS are attached to them
+    output$mytable2 <- DT::renderDataTable({
+        DT::datatable(mtcars, options = list(orderClasses = TRUE))
+    })
+
+    # customize the length drop-down menu; display 5 rows per page by default
+    output$mytable3 <- DT::renderDataTable({
+        DT::datatable(
+            iris,
+            options = list(lengthMenu = c(5, 30, 50), pageLength = 5)
+        )
+    })
+}
+
+shinyApp(ui, server)


### PR DESCRIPTION
This pull request introduces a new example to the Shiny gallery, demonstrating the use of DataTables in a Shiny application. The changes include adding a new entry to the gallery index and implementing the corresponding Shiny app.

### Addition of a new Shiny example:

* **Gallery index update**:
  - Added a new entry, `"ex13": "13-datatables-demo.R"`, to the `gallery.json` file to include the new example in the gallery.

* **New Shiny app implementation**:
  - Created a new Shiny app in `template/shiny/13-datatables-demo.R` to demonstrate various features of DataTables, including conditional column selection, sorting, and pagination customization for datasets (`diamonds`, `mtcars`, and `iris`).