### PR TITLE
feat: ex14

### DIFF
--- a/gallery.json
+++ b/gallery.json
@@ -7,6 +7,7 @@
   "ex08": "08-movieexploer.R",
   "ex10": "10-datatable.R",
   "ex13": "13-datatables-demo.R",
+  "ex14": "14-datatables-options.R",
   "ex26": "26-absolute.R",
   "ex36": "36-dynamic.R",
   "ex39": "39-observer.R",

--- a/template/shiny/14-datatables-options.R
+++ b/template/shiny/14-datatables-options.R
@@ -1,0 +1,52 @@
+ui <- navbarPage(
+    title = 'DataTable Options',
+    tabPanel('Display length', DT::dataTableOutput('ex1')),
+    tabPanel('Length menu', DT::dataTableOutput('ex2')),
+    tabPanel('No pagination', DT::dataTableOutput('ex3')),
+    tabPanel('No filtering', DT::dataTableOutput('ex4')),
+    tabPanel('Function callback', DT::dataTableOutput('ex5'))
+)
+
+server <- function(input, output) {
+    # display 10 rows initially
+    output$ex1 <- DT::renderDataTable(
+        DT::datatable(iris, options = list(pageLength = 25))
+    )
+
+    # -1 means no pagination; the 2nd element contains menu labels
+    output$ex2 <- DT::renderDataTable(
+        DT::datatable(
+            iris,
+            options = list(
+                lengthMenu = list(c(5, 15, -1), c('5', '15', 'All')),
+                pageLength = 15
+            )
+        )
+    )
+
+    # you can also use paging = FALSE to disable pagination
+    output$ex3 <- DT::renderDataTable(
+        DT::datatable(iris, options = list(paging = FALSE))
+    )
+
+    # turn off filtering (no searching boxes)
+    output$ex4 <- DT::renderDataTable(
+        DT::datatable(iris, options = list(searching = FALSE))
+    )
+
+    # write literal JS code in JS()
+    output$ex5 <- DT::renderDataTable(DT::datatable(
+        iris,
+        options = list(
+            rowCallback = DT::JS(
+                'function(row, data) {
+        // Bold cells for those >= 5 in the first column
+        if (parseFloat(data[1]) >= 5.0)
+          $("td:eq(1)", row).css("font-weight", "bold");
+      }'
+            )
+        )
+    ))
+}
+
+shinyApp(ui = ui, server = server)


### PR DESCRIPTION
This pull request introduces a new example to the gallery showcasing advanced DataTable options in Shiny applications. The most notable changes include adding a reference to the new example in the `gallery.json` file and implementing the example in a new script file.

### Updates to the gallery:

* [`gallery.json`](diffhunk://#diff-0b884235535f1a24d03c6a5a31cad797f7dd65c708988ff0f1b948ae73bcd370R10): Added a reference to the new example (`ex14`) titled "DataTable Options," linking to the corresponding script file `14-datatables-options.R`.

### Implementation of the new example:

* [`template/shiny/14-datatables-options.R`](diffhunk://#diff-37541aa3b405cc01434fd4eefb4243961796049f3b5565a62757a858e6bb127aR1-R52): Created a new Shiny application script demonstrating various DataTable options, including display length, length menu, pagination settings, filtering, and JavaScript callbacks for row styling.