### PR TITLE
feat: ex17

### DIFF
--- a/gallery.json
+++ b/gallery.json
@@ -10,6 +10,7 @@
   "ex14": "14-datatables-options.R",
   "ex15": "15-dateranges.R",
   "ex16": "16-dynamic-clustering.R",
+  "ex17": "17-file-download.R",
   "ex26": "26-absolute.R",
   "ex36": "36-dynamic.R",
   "ex39": "39-observer.R",

--- a/template/shiny/17-file-download.R
+++ b/template/shiny/17-file-download.R
@@ -1,0 +1,59 @@
+library(shiny)
+
+# Define UI for data download app ----
+ui <- fluidPage(
+    # App title ----
+    titlePanel("Downloading Data"),
+
+    # Sidebar layout with input and output definitions ----
+    sidebarLayout(
+        # Sidebar panel for inputs ----
+        sidebarPanel(
+            # Input: Choose dataset ----
+            selectInput(
+                "dataset",
+                "Choose a dataset:",
+                choices = c("rock", "pressure", "cars")
+            ),
+
+            # Button
+            downloadButton("downloadData", "Download")
+        ),
+
+        # Main panel for displaying outputs ----
+        mainPanel(
+            tableOutput("table")
+        )
+    )
+)
+
+# Define server logic to display and download selected file ----
+server <- function(input, output) {
+    # Reactive value for selected dataset ----
+    datasetInput <- reactive({
+        switch(
+            input$dataset,
+            "rock" = rock,
+            "pressure" = pressure,
+            "cars" = cars
+        )
+    })
+
+    # Table of selected dataset ----
+    output$table <- renderTable({
+        datasetInput()
+    })
+
+    # Downloadable csv of selected dataset ----
+    output$downloadData <- downloadHandler(
+        filename = function() {
+            paste(input$dataset, ".csv", sep = "")
+        },
+        content = function(file) {
+            write.csv(datasetInput(), file, row.names = FALSE)
+        }
+    )
+}
+
+# Create Shiny app ----
+shinyApp(ui, server)


### PR DESCRIPTION
This pull request adds a new Shiny app example for file downloads and updates the `gallery.json` file to include this new example. The changes introduce functionality for users to download datasets in CSV format via a Shiny app interface.

### Addition of a new Shiny app example:

* [`template/shiny/17-file-download.R`](diffhunk://#diff-2a31c1e9ed2f5c8da5ae855b39d9b8c24b0ad9ede0394fc84372a12337029e25R1-R59): Added a complete Shiny app implementation that allows users to select a dataset (`rock`, `pressure`, or `cars`), view it in a table, and download it as a CSV file. The app includes both UI and server logic for these functionalities.

### Update to the gallery index:

* [`gallery.json`](diffhunk://#diff-0b884235535f1a24d03c6a5a31cad797f7dd65c708988ff0f1b948ae73bcd370R13): Added an entry for the new example (`ex17`) that maps to the `17-file-download.R` file. This ensures the example is included in the gallery index.