### PR TITLE
feat: linux-deb

### DIFF
--- a/commands/build.js
+++ b/commands/build.js
@@ -3,7 +3,7 @@ import { execSync } from "child_process";
 import path from "path";
 import fs from "fs";
 import { exitWithError } from "../utils/zzz.js";
-import { handleDmgMaker, handleSquirrelMaker } from "../utils/maker.js";
+import { handleDmgMaker, handleSquirrelMaker, handleDebMaker } from "../utils/maker.js"; // updated import
 
 export const buildCommand = new Command("build")
   .argument("<name>", "Project name")
@@ -22,7 +22,7 @@ export const buildCommand = new Command("build")
     }
 
     const maker = options.maker;
-    const supportedMakers = ["dmg", "zip", "squirrel"];
+    const supportedMakers = ["dmg", "zip", "squirrel", "deb"]; // add "deb"
     if (!supportedMakers.includes(maker)) {
       return exitWithError(
         `Invalid maker type specified: '${maker}'. Supported types are: ${supportedMakers.join(
@@ -37,7 +37,9 @@ export const buildCommand = new Command("build")
       if (maker === "dmg") {
         await handleDmgMaker(root, projectPath, name);
       } else if (maker === "squirrel") {
-        await handleSquirrelMaker(root, projectPath);
+        await handleSquirrelMaker(projectPath);
+      } else if (maker === "deb") {
+        await handleDebMaker(projectPath);
       }
 
       console.log(`Building Electron app with maker: ${maker}...`);

--- a/commands/init.js
+++ b/commands/init.js
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import path from "path";
 import { handleDirectory } from "../utils/directory.js";
 import { copyTemplates } from "../utils/template.js";
-import { installDependencies } from "../utils/install.js";
+import { installDependencies, installStandaloneR } from "../utils/install.js";
 import { updateGitignore } from "../utils/zzz.js";
 
 export const initCommand = new Command("init")
@@ -17,6 +17,7 @@ export const initCommand = new Command("init")
     await handleDirectory(projectPath, name, options.overwrite);
     updateGitignore(root, name);
     copyTemplates(templatePath, projectPath, name);
+    installStandaloneR();
     installDependencies(projectPath);
 
     console.log(`Project '${name}' fully initialized.`);

--- a/utils/install.js
+++ b/utils/install.js
@@ -8,17 +8,19 @@ const __dirname = path.dirname(__filename);
 export function installDependencies(projectPath) {
   process.chdir(projectPath);
 
-  try {
-    console.log("Installing standalone R...");
-    const rShellScriptPath = path.join(__dirname, "r.sh");
-    execSync(`sh "${rShellScriptPath}"`, { stdio: "inherit" });
-
+  try {    
     installRPackages();
     installNodePackages();
   } catch (err) {
     console.error("Setup or launch failed:", err.message);
     process.exit(1);
   }
+}
+
+export function installStandaloneR() {
+  console.log("Installing standalone R...");
+  const rShellScriptPath = path.join(__dirname, "r.sh");
+  execSync(`sh "${rShellScriptPath}"`, { stdio: "inherit" });
 }
 
 function runRscriptCommand(rscriptCmd, platformLabel = "") {

--- a/utils/maker.js
+++ b/utils/maker.js
@@ -60,7 +60,7 @@ export async function handleDmgMaker(
   await updateForgeConfig(projectPath, dmgMakerConfig);
 }
 
-export async function handleSquirrelMaker(root, projectPath) {
+export async function handleSquirrelMaker(projectPath) {
   const dependenciesUpdated = updatePackageJson(projectPath, {
     dependencies: { "electron-squirrel-startup": "^1.0.1" },
     devDependencies: { "@electron-forge/maker-squirrel": "^7.8.0" },
@@ -80,4 +80,20 @@ export async function handleSquirrelMaker(root, projectPath) {
   };
 
   await updateForgeConfig(projectPath, squirrelMakerConfig);
+}
+
+export async function handleDebMaker(projectPath) {
+  const dependenciesUpdated = updatePackageJson(projectPath, {
+    devDependencies: { "@electron-forge/maker-deb": "^7.8.1" },
+  });
+
+  if (dependenciesUpdated) {
+    installDependencies(projectPath);
+  }
+
+  const debMakerConfig = {
+    name: "@electron-forge/maker-deb",
+  };
+
+  await updateForgeConfig(projectPath, debMakerConfig);
 }


### PR DESCRIPTION
This pull request introduces support for building `.deb` packages for Electron apps and refactors the installation process for standalone R scripts. The key changes include adding a new maker for `.deb` packages, creating a dedicated function for standalone R installation, and updating related configurations and dependencies.

### Support for `.deb` package building:

* [`commands/build.js`](diffhunk://#diff-69f79a85792b29ae524e0418803900436b9bebf218bde8b8c8b51ad573e3017fL6-R6): Added `.deb` to the list of supported makers, updated the maker selection logic to handle `.deb`, and imported the new `handleDebMaker` function. [[1]](diffhunk://#diff-69f79a85792b29ae524e0418803900436b9bebf218bde8b8c8b51ad573e3017fL6-R6) [[2]](diffhunk://#diff-69f79a85792b29ae524e0418803900436b9bebf218bde8b8c8b51ad573e3017fL25-R25) [[3]](diffhunk://#diff-69f79a85792b29ae524e0418803900436b9bebf218bde8b8c8b51ad573e3017fL40-R42)
* [`utils/maker.js`](diffhunk://#diff-89d294b2ca34383cfd33f2bcf3e5cc71be81523de43bd21a84efba79be616affR84-R99): Introduced the `handleDebMaker` function to configure and install dependencies for `.deb` package creation.

### Refactoring standalone R installation:

* [`commands/init.js`](diffhunk://#diff-7f753ac549cdac69358e8c9d993f5b168a1af2006679278fab5219256b7aff7cL5-R5): Added a call to the newly created `installStandaloneR` function during the initialization process and updated the import statement. [[1]](diffhunk://#diff-7f753ac549cdac69358e8c9d993f5b168a1af2006679278fab5219256b7aff7cL5-R5) [[2]](diffhunk://#diff-7f753ac549cdac69358e8c9d993f5b168a1af2006679278fab5219256b7aff7cR20)
* [`utils/install.js`](diffhunk://#diff-6353e19b0b6aac3766b2509a3cf9f8a4cc4ab87593b5baa861fcbbbb31dfa934L12-L15): Moved the standalone R installation logic into a new `installStandaloneR` function, separating it from the `installDependencies` function for better modularity. [[1]](diffhunk://#diff-6353e19b0b6aac3766b2509a3cf9f8a4cc4ab87593b5baa861fcbbbb31dfa934L12-L15) [[2]](diffhunk://#diff-6353e19b0b6aac3766b2509a3cf9f8a4cc4ab87593b5baa861fcbbbb31dfa934R20-R25)

### Minor refactor:

* [`utils/maker.js`](diffhunk://#diff-89d294b2ca34383cfd33f2bcf3e5cc71be81523de43bd21a84efba79be616affL63-R63): Removed the unused `root` parameter from the `handleSquirrelMaker` function to simplify the function signature.