### PR TITLE
Resolve template with __dirname and harden utils

### DIFF
--- a/commands/init.js
+++ b/commands/init.js
@@ -1,26 +1,30 @@
 import { Command } from "commander";
 import path from "path";
+import { fileURLToPath } from "url";
 import { handleDirectory } from "../utils/directory.js";
 import { copyTemplates } from "../utils/template.js";
 import { installDependencies, installStandaloneR } from "../utils/install.js";
 import { updateGitignore } from "../utils/zzz.js";
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 export const initCommand = new Command("init")
-  .argument("<name>", "Project name")
-  .option("-w, --overwrite", "Overwrite if directory exists")
-  .description("Initialize, install dependencies, and run a nhyris project")
-  .action(async (name, options) => {
-    const root = process.cwd();
-    const projectPath = path.join(root, name);
-    const templatePath = path.resolve("template");
+    .argument("<name>", "Project name")
+    .option("-w, --overwrite", "Overwrite if directory exists")
+    .description("Initialize, install dependencies, and run a nhyris project")
+    .action(async (name, options) => {
+        const root = process.cwd();
+        const projectPath = path.join(root, name);
+        const templatePath = path.resolve(__dirname, "../template");
 
-    await handleDirectory(projectPath, name, options.overwrite);
-    updateGitignore(root, name);
-    copyTemplates(templatePath, projectPath, name);
-    installStandaloneR(projectPath);
-    installDependencies(projectPath);
+        await handleDirectory(projectPath, name, options.overwrite);
+        updateGitignore(root, name);
+        copyTemplates(templatePath, projectPath, name);
+        installStandaloneR(projectPath);
+        installDependencies(projectPath);
 
-    console.log(`Project '${name}' fully initialized.`);
-    console.log(`run application using nhyris run ${name} command`);
-    console.log("Please modify package.json as needed.");
-  });
+        console.log(`Project '${name}' fully initialized.`);
+        console.log(`run application using nhyris run ${name} command`);
+        console.log("Please modify package.json as needed.");
+    });

--- a/utils/zzz.js
+++ b/utils/zzz.js
@@ -2,113 +2,121 @@ import fs from "fs";
 import path from "path";
 
 export function exitWithError(message) {
-  console.error(`${message}`);
-  process.exit(1);
+    console.error(`${message}`);
+    process.exit(1);
 }
 
 export function updatePackageJson(projectPath, updates) {
-  const packageJsonPath = path.join(projectPath, "package.json");
-  if (!fs.existsSync(packageJsonPath)) {
-    console.warn("package.json not found in the project directory.");
-    return false;
-  }
+    const packageJsonPath = path.join(projectPath, "package.json");
+    if (!fs.existsSync(packageJsonPath)) {
+        console.warn("package.json not found in the project directory.");
+        return false;
+    }
 
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
-  let updated = false;
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+    let updated = false;
 
-  for (const [key, value] of Object.entries(updates)) {
-    packageJson[key] = { ...packageJson[key], ...value };
-    updated = true;
-  }
+    for (const [key, value] of Object.entries(updates)) {
+        packageJson[key] = { ...packageJson[key], ...value };
+        updated = true;
+    }
 
-  if (updated) {
-    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
-    console.log("Updated package.json.");
-  }
+    if (updated) {
+        fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+        console.log("Updated package.json.");
+    }
 
-  return updated;
+    return updated;
 }
 
 export async function updateForgeConfig(projectPath, makerConfig) {
-  const forgeConfigPath = path.join(projectPath, "forge.config.js");
-  console.log("Updating forge.config.js...");
+    const forgeConfigPath = path.join(projectPath, "forge.config.js");
+    console.log("Updating forge.config.js...");
 
-  try {
-    const forgeConfigModule = await import(`file://${forgeConfigPath}`);
-    const forgeConfig = forgeConfigModule.default;
+    try {
+        const forgeConfigModule = await import(`file://${forgeConfigPath}`);
+        const forgeConfig = forgeConfigModule.default;
 
-    const existingMakerIndex = forgeConfig.makers.findIndex(
-      (m) => m.name === makerConfig.name
-    );
+        const existingMakerIndex = forgeConfig.makers.findIndex(
+            (m) => m.name === makerConfig.name
+        );
 
-    if (existingMakerIndex > -1) {
-      forgeConfig.makers[existingMakerIndex] = makerConfig;
-      console.log(`Updated existing ${makerConfig.name} maker configuration.`);
-    } else {
-      forgeConfig.makers.push(makerConfig);
-      console.log(`Added ${makerConfig.name} maker configuration.`);
+        if (existingMakerIndex > -1) {
+            forgeConfig.makers[existingMakerIndex] = makerConfig;
+            console.log(`Updated existing ${makerConfig.name} maker configuration.`);
+        } else {
+            forgeConfig.makers.push(makerConfig);
+            console.log(`Added ${makerConfig.name} maker configuration.`);
+        }
+
+        const updatedConfigString = serializeObject(forgeConfig, 2);
+
+        fs.writeFileSync(
+            forgeConfigPath,
+            `module.exports = ${updatedConfigString};`
+        );
+        console.log("Updated forge.config.js.");
+    } catch (err) {
+        throw new Error(`Error loading forge.config.js: ${err.message}`);
     }
-
-    const updatedConfigString = serializeObject(forgeConfig, 2);
-
-    fs.writeFileSync(
-      forgeConfigPath,
-      `module.exports = ${updatedConfigString};`
-    );
-    console.log("Updated forge.config.js.");
-  } catch (err) {
-    throw new Error(`Error loading forge.config.js: ${err.message}`);
-  }
 }
 
 export function updateGitignore(root, name) {
-  const gitignorePath = path.join(root, ".gitignore");
+    const gitignorePath = path.join(root, ".gitignore");
 
-  try {
-    const gitignoreContent = fs.readFileSync(gitignorePath, "utf-8");
+    try {
+        if (!fs.existsSync(gitignorePath)) {
+            fs.writeFileSync(gitignorePath, "", "utf-8");
+        }
 
-    if (!gitignoreContent.includes(`${name}/`)) {
-      fs.appendFileSync(gitignorePath, `\n${name}/\n`);
-      console.log(`Added '${name}/' to .gitignore`);
+        const gitignoreContent = fs.readFileSync(gitignorePath, "utf-8");
+        const ignoreEntry = `${name}/`;
+
+        if (!gitignoreContent.includes(ignoreEntry)) {
+            const needsLeadingNewline =
+                gitignoreContent.length > 0 && !gitignoreContent.endsWith("\n");
+            const prefix = needsLeadingNewline ? "\n" : "";
+            fs.appendFileSync(gitignorePath, `${prefix}${ignoreEntry}\n`);
+            console.log(`Added '${name}/' to .gitignore`);
+        }
+    } catch (err) {
+        console.error(`Failed to update .gitignore: ${err.message}`);
     }
-  } catch (err) {
-    console.error(`Failed to update .gitignore: ${err.message}`);
-  }
 }
 
 const INDENT_STEP = 2;
 
 function serializeObject(obj, indent = INDENT_STEP) {
-  const isValidIdentifier = (key) => /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key);
-  if (Array.isArray(obj)) {
-    return (
-      "[\n" +
-      obj
-        .map(
-          (v) => " ".repeat(indent) + serializeObject(v, indent + INDENT_STEP)
-        )
-        .join(",\n") +
-      "\n" +
-      " ".repeat(indent - INDENT_STEP) +
-      "]"
-    );
-  } else if (obj && typeof obj === "object") {
-    return (
-      "{\n" +
-      Object.entries(obj)
-        .map(([k, v]) => {
-          const key = isValidIdentifier(k) ? k : JSON.stringify(k);
-          return (
-            " ".repeat(indent) +
-            `${key}: ${serializeObject(v, indent + INDENT_STEP)}`
-          );
-        })
-        .join(",\n") +
-      "\n" +
-      " ".repeat(indent - INDENT_STEP) +
-      "}"
-    );
-  } else {
-    return JSON.stringify(obj);
-  }
+    const isValidIdentifier = (key) => /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key);
+    if (Array.isArray(obj)) {
+        return (
+            "[\n" +
+            obj
+                .map(
+                    (v) => " ".repeat(indent) + serializeObject(v, indent + INDENT_STEP)
+                )
+                .join(",\n") +
+            "\n" +
+            " ".repeat(indent - INDENT_STEP) +
+            "]"
+        );
+    } else if (obj && typeof obj === "object") {
+        return (
+            "{\n" +
+            Object.entries(obj)
+                .map(([k, v]) => {
+                    const key = isValidIdentifier(k) ? k : JSON.stringify(k);
+                    return (
+                        " ".repeat(indent) +
+                        `${key}: ${serializeObject(v, indent + INDENT_STEP)}`
+                    );
+                })
+                .join(",\n") +
+            "\n" +
+            " ".repeat(indent - INDENT_STEP) +
+            "}"
+        );
+    } else {
+        return JSON.stringify(obj);
+    }
 }


### PR DESCRIPTION
Use fileURLToPath to derive __dirname in commands/init.js and resolve the template path relative to the module file instead of CWD. Also reformat and harden utils/zzz.js: normalize updatePackageJson logic, keep updateForgeConfig intact, and make updateGitignore more robust (create .gitignore if missing, preserve newline handling when appending, and better error messages). Overall cleanup improves path resolution and error resilience when initializing projects.